### PR TITLE
Color attributes are now working as expected

### DIFF
--- a/monitor/ActionMonitor/Actions.cpp
+++ b/monitor/ActionMonitor/Actions.cpp
@@ -196,7 +196,7 @@ const std::wstring Actions::ToChar( const IAction& givenAction, const CommandsVa
   ret += sBoldC;
   if (givenAction.Extention().length() > 0)
   {
-    ret += myodd::strings::Format(L"<small style='color:#d3c31a'>(% s)</small>", givenAction.Extention().c_str());
+    ret += myodd::strings::Format(L"<small style='color:#a69914'>(% s)</small>", givenAction.Extention().c_str());
   }
   ret += sItalicC;
 

--- a/monitor/ActionMonitor/Application.cpp
+++ b/monitor/ActionMonitor/Application.cpp
@@ -430,7 +430,7 @@ void Application::ShowStart()
 void Application::ShowVersion()
 {
   myodd::files::Version ver;
-  const auto strSay = myodd::strings::Format(L"<b>Version: </b><i>%d.%d.%d.%d</i>",
+  const auto strSay = myodd::strings::Format(L"<b>Version: </b><i style='color:#a69914'>%d.%d.%d.%d</i>",
     ver.GetFileVersionMajor(),
     ver.GetFileVersionMinor(),
     ver.GetFileVersionMaintenance(),

--- a/myodd/html/Attribute.cpp
+++ b/myodd/html/Attribute.cpp
@@ -52,4 +52,24 @@ void Attribute::Add(const AttributeValue& value)
 {
   _values.push_back(AttributeValue::CreateFromSource(value));
 }
+
+// apply the style
+void Attribute::Push(HDC hdc, LOGFONT& logFont)
+{
+  //  we push from start to end
+  for (auto att : _values)
+  {
+    att->Push(hdc, logFont);
+  }
+}
+
+// remove the style
+void Attribute::Pop(HDC hdc, LOGFONT& logFont)
+{
+  // we pop in reverse order
+  for (auto it = _values.rbegin(); it != _values.rend(); it++)
+  {
+    (*it)->Pop(hdc, logFont);
+  }
+}
 }}

--- a/myodd/html/Attribute.h
+++ b/myodd/html/Attribute.h
@@ -14,10 +14,10 @@ public:
   Attribute& operator=(const Attribute&);
     
   // apply the style
-  virtual void Push(HDC hdc, LOGFONT& logFont ) = 0;
+  virtual void Push(HDC hdc, LOGFONT& logFont );
 
   // remove the style
-  virtual void Pop(HDC hdc, LOGFONT& logFont ) = 0;
+  virtual void Pop(HDC hdc, LOGFONT& logFont );
 
   /**
    * \brief add a single attribute value

--- a/myodd/html/AttributeStyle.cpp
+++ b/myodd/html/AttributeStyle.cpp
@@ -30,11 +30,13 @@ void AttributeStyle::Clear()
 // apply the styles
 void AttributeStyle::Push(HDC hdc, LOGFONT& logFont)
 {
+  __super::Push(hdc, logFont);
 }
 
 // remove the style
 void AttributeStyle::Pop(HDC hdc, LOGFONT& logFont)
 {
+  __super::Pop(hdc, logFont);
 }
 
 void AttributeStyle::Copy(const Attribute& rhs)

--- a/myodd/html/AttributeValueColor.cpp
+++ b/myodd/html/AttributeValueColor.cpp
@@ -109,5 +109,6 @@ void AttributeValueColor::Copy(const AttributeValueColor& rhs)
 
   // copy variables.
   _rgb = rhs._rgb;
+  _previousColor = rhs._previousColor;
 }
 }}

--- a/myodd/html/AttributeValueColor.cpp
+++ b/myodd/html/AttributeValueColor.cpp
@@ -2,13 +2,15 @@
 #include "AttributeValueColor.h"
 
 namespace myodd{ namespace html{
-AttributeValueColor::AttributeValueColor(const std::wstring& color)
+AttributeValueColor::AttributeValueColor(const std::wstring& color) :
+  _previousColor(-1)
 {
   _rgb = CreateColor(color);
 }
 
 AttributeValueColor::AttributeValueColor(const AttributeValueColor& rhs) :
-  AttributeValue( rhs )
+  AttributeValue( rhs ),
+  _previousColor( -1 )
 {
   Copy(rhs);
 }
@@ -22,13 +24,20 @@ AttributeValueColor& AttributeValueColor::operator=(const AttributeValueColor& r
 // apply the style
 void AttributeValueColor::Push(HDC hdc, LOGFONT& logFont)
 {
-
+  UNUSED_ALWAYS(logFont);
+  _previousColor = SetTextColor( hdc, RGB(_rgb.r, _rgb.g, _rgb.b ));
 }
 
 // remove the style
 void AttributeValueColor::Pop(HDC hdc, LOGFONT& logFont)
 {
-
+  UNUSED_ALWAYS(logFont);
+  //  restore the old one
+  if (_previousColor != -1)
+  {
+    SetTextColor( hdc, _previousColor );
+  }
+  _previousColor = -1;
 }
 
 AttributeValueColor::RGB AttributeValueColor::CreateColor(const std::wstring& color)

--- a/myodd/html/AttributeValueColor.h
+++ b/myodd/html/AttributeValueColor.h
@@ -35,5 +35,7 @@ protected:
 
   static RGB CreateColor(const std::wstring& color);
   static unsigned short HexToInt(const std::wstring& hex );
+
+  COLORREF _previousColor;
 };
 }}

--- a/myodd/html/AttributeValueColor.h
+++ b/myodd/html/AttributeValueColor.h
@@ -30,12 +30,17 @@ protected:
   // copy the attribute values here.
   virtual void Copy(const AttributeValueColor& rhs);
 
-  // the actual color
-  RGB _rgb;
-
   static RGB CreateColor(const std::wstring& color);
   static unsigned short HexToInt(const std::wstring& hex );
 
+  /**
+   * \brief the colour we want to change our text to.
+   */
+  RGB _rgb;
+
+  /**
+   * \brief if not -1, then it is the color we need to pop back tp
+   */
   COLORREF _previousColor;
 };
 }}

--- a/myodd/html/Tag.cpp
+++ b/myodd/html/Tag.cpp
@@ -69,6 +69,9 @@ void Tag::Pop(HDC hdc, LOGFONT& logFont )
   if( _depth >= 1 )
   {
     // pop the attributes
+    _attributes.Pop(hdc, logFont);
+
+    // then the main tag style
     OnPop(hdc, logFont );
     --_depth;
   }


### PR DESCRIPTION
You can now set the color as a style for example `<i style="color:#a69914">...</i>` as an example the version text now has a color but the user should be able to set the color as well.