### PR TITLE
Fix/string size

### DIFF
--- a/monitor/ActionMonitor/MessageDlg.cpp
+++ b/monitor/ActionMonitor/MessageDlg.cpp
@@ -68,7 +68,7 @@ void MessageDlg::InitWindowPos()
   const auto pOldFont = SelDisplayFont( hdc, 35 );
 
   RECT r = {0,0,0,0};
-  myodd::html::html(hdc, _mStdMessage.c_str() , _mStdMessage.length(), &r, -1, -1, -1, DT_DEFAULT | DT_CALCRECT );
+  myodd::html::html(hdc, _mStdMessage.c_str() , static_cast<int>(_mStdMessage.length()), &r, -1, -1, -1, DT_DEFAULT | DT_CALCRECT);
 
   //  clean up old fonts
   if ( pOldFont != nullptr )
@@ -271,13 +271,13 @@ void MessageDlg::RedrawMessage(const HDC hdc)
   // get the full rectangle size to display the full item
   // we do not need to pass the single line height as we already know the biggest height.
   RECT r = { 0,0,0,0 };
-  myodd::html::html(hdc, _mStdMessage.c_str(), _mStdMessage.length(), &r, -1, paddingY, paddingY, DT_DEFAULT | DT_CALCRECT);
+  myodd::html::html(hdc, _mStdMessage.c_str(), static_cast<int>(_mStdMessage.length()), &r, -1, paddingY, paddingY, DT_DEFAULT | DT_CALCRECT);
 
   //  pad a little
   r.left += static_cast<int>(::myodd::config::Get(L"commands\\pad.x", 2));
 
   // now we do the actual item print.
-  myodd::html::html(hdc, _mStdMessage.c_str(), _mStdMessage.length(), &r, maxSingleLineHeight, paddingY, paddingY, DT_DEFAULT);
+  myodd::html::html(hdc, _mStdMessage.c_str(), static_cast<int>(_mStdMessage.length()), &r, maxSingleLineHeight, paddingY, paddingY, DT_DEFAULT);
 
   //  clean up old fonts
   if (pOldFont != nullptr)

--- a/monitor/api/pyapi.cpp
+++ b/monitor/api/pyapi.cpp
@@ -615,6 +615,13 @@ PyObject* PyApi::FindAction(PyObject *self, PyObject *args) const
       return Fail();
     }
 
+    if ( nullptr == szText )
+    {
+      Say(L"<b>Error : </b> Missing action name.");
+      __super::Log(AM_LOG_ERROR, L"Python: FindAction( ... ): Action name is null");
+      return Fail();
+    }
+
     const auto action = HelperApi::FindAction(idx, HelperApi::Widen(szText));
     if (action == nullptr )
     {

--- a/myodd/html/AttributesParser.cpp
+++ b/myodd/html/AttributesParser.cpp
@@ -31,7 +31,7 @@ Attributes AttributesParser::Parse(const std::wstring& text) const
  */
 Attributes AttributesParser::Parse(const wchar_t* lpString ) const
 {
-  auto totalLen = lpString == nullptr ? 0 : _tcslen(lpString);
+  const auto totalLen = static_cast<int>(lpString == nullptr ? 0 : wcslen(lpString));
   if (totalLen == 0 )
   {
     return Attributes();

--- a/myodd/os/ipcdata.cpp
+++ b/myodd/os/ipcdata.cpp
@@ -662,8 +662,11 @@ std::wstring IpcData::ReadString(unsigned char* pData, const size_t dataSize, si
 
     // make sure we can read this.
     ThrowIfReadingPastSize(dataSize, pointer, sizeof(stringSize));
-
-    memcpy_s(&stringSize, sizeof(dataSize), pData + pointer, sizeof(stringSize));
+    memcpy_s(&stringSize,   //  (void* dest)
+      sizeof(stringSize),   //  max dest size
+      pData + pointer,      //  (void* src)
+      sizeof(stringSize)    //  size of src
+    );
 
     // update the pointer location.
     pointer += sizeof(stringSize);
@@ -752,8 +755,12 @@ std::string IpcData::ReadAsciiString(unsigned char* pData, const size_t dataSize
 
     // make sure we can read this.
     ThrowIfReadingPastSize(dataSize, pointer, sizeof(stringSize));
+    memcpy_s(&stringSize,   //  (void* dest)
+      sizeof(stringSize),   //  max dest size
+      pData + pointer,      //  (void* src)
+      sizeof(stringSize)    //  size of src
+    );
 
-    memcpy_s(&stringSize, sizeof(stringSize), pData + pointer, sizeof(stringSize));
 
     // update the pointer location.
     pointer += sizeof(stringSize);

--- a/myodd/string/string.cpp
+++ b/myodd/string/string.cpp
@@ -118,30 +118,30 @@ std::wstring MakeUuid4()
 }
 
 /**
- * Explode a string that is separated with '\0' chars.
- * This is used with items like GetPrivateProfileString( ... ) when we want to list all the keys.
- * @param std::vector<std::wstring>& the return container.
- * @param const wchar_t* the string with null chars '\0' finished by '\0\0'
- * @param size_t the length of the string. 
- * @return int the number of items returned.
+ * \brief Explode a string that is separated with '\0' chars.
+ *        This is used with items like GetPrivateProfileString( ... ) when we want to list all the keys.
+ * \param ret the return container.
+ * \param s_keys the string with null chars '\0' finished by '\0\0'
+ * \param nLen the length of the string. 
+ * \return int the number of items we exploded the string to.
  */
-size_t explode_by_null_char
+unsigned int explode_by_null_char
 (
   std::vector<std::wstring>& ret,
   const wchar_t* s_keys,
-  size_t nLen
+  unsigned int nLen
 )
 {
-  size_t retSize = 0;
+  unsigned int retSize = 0;
   std::wstring stdToken;
-  for(size_t nPos = 0; nPos < nLen; ++nPos )
+  for(unsigned int nPos = 0; nPos < nLen; ++nPos )
   {
-    if( s_keys[ nPos ] == _T('\0') )
+    if( s_keys[ nPos ] == L'\0' )
     {
       ++retSize;
       ret.push_back( stdToken );
       stdToken.clear();
-      if( nPos > 0 && s_keys[ nPos-1 ] == _T('\0'))
+      if( nPos > 0 && s_keys[ nPos-1 ] == L'\0')
       {
         break;
       }
@@ -155,21 +155,21 @@ size_t explode_by_null_char
 }
 
 /**
- * Explode a given string given a delimiter string
- * @param std::vector<std::wstring>& the return container.
- * @param std::wstring the string we want to explode
- * @param const wchar_t* Set of delimiter characters.
- * @param int nCount the max number of items we want to return.
- *                   If the limit parameter is zero, then this is treated as 1.
- * @param bool bAddEmpty if we want to add empty params or not.
- * @return int the number of item that we found.
+ * \brief Explode a given string given a delimiter string
+ * \param ret the return container.
+ * \param stringToExplode the string we want to explode
+ * \param strDelimit Set of delimiter characters.
+ * \param nCount the max number of items we want to return.
+ *               If the limit parameter is zero, then this is treated as 1.
+ * \param bAddEmpty if we want to add empty params or not.
+ * \return the number of item that we found.
  */
-size_t Explode
+unsigned int Explode
 (
   std::vector<std::wstring>& ret,
-  const std::wstring& s, 
+  const std::wstring& stringToExplode, 
   wchar_t strDelimit,
-  int nCount /*=MYODD_MAX_INT32*/,
+  unsigned int nCount /*=MYODD_MAX_INT32*/,
   bool bAddEmpty /*= true*/
 )
 {
@@ -180,7 +180,7 @@ size_t Explode
   // If the limit parameter is zero, then this is treated as 1.
   if( 1 == nCount || 0 == nCount )
   {
-    ret.push_back( s );
+    ret.push_back(stringToExplode);
     return 1;
   }
   
@@ -191,19 +191,19 @@ size_t Explode
   }
 
   // get the given vector length 
-  const auto length = s.length();
+  const auto length = stringToExplode.length();
 
   // The number of items we actually found
-  size_t retSize = 0;
-  size_t iLast = 0;
+  unsigned int retSize = 0;
+  unsigned int iLast = 0;
 
   // NB: This loop will go _past_ the length of our string.
   //     This is done so we can add the last string once we get the end
-  for( auto pos = 0; pos <= length; ++pos)
+  for( unsigned int pos = 0; pos <= length; ++pos)
   {
     if( 
        pos == length ||     // we reached the end of the string
-       s[pos] == strDelimit // or the char is what we are looking for.
+       stringToExplode[pos] == strDelimit // or the char is what we are looking for.
       )
     {
       if( bAddEmpty || (pos-iLast) > 0 )
@@ -213,15 +213,15 @@ size_t Explode
         {
           // we have collected more items than we want.
           // so we can just stop here and add everything else to our container.
-          ret.push_back( s.substr(iLast));
+          ret.push_back(stringToExplode.substr(iLast));
           break;
         }
 
         ret.push_back( 
             pos == length ?
-              s.substr(iLast)
+              stringToExplode.substr(iLast)
               :
-              s.substr(iLast, (pos-iLast) ));
+              stringToExplode.substr(iLast, (pos-iLast) ));
       }
       iLast = (pos+1);
     }

--- a/myodd/string/string.cpp
+++ b/myodd/string/string.cpp
@@ -159,8 +159,10 @@ unsigned int explode_by_null_char
  * \param ret the return container.
  * \param stringToExplode the string we want to explode
  * \param strDelimit Set of delimiter characters.
- * \param nCount the max number of items we want to return.
- *               If the limit parameter is zero, then this is treated as 1.
+ * \param maxnumberOfElements the max number of items we want to return.
+ *               If the limit parameter is zero, then this is treated as 1, (and only return one element).
+ *               If the value is negative, we return the (total - n) number of elements, (from 0 to total - count)
+ *                  If the negative number is greater than the total number of elements, we return nothing.
  * \param bAddEmpty if we want to add empty params or not.
  * \return the number of item that we found.
  */
@@ -169,25 +171,25 @@ unsigned int Explode
   std::vector<std::wstring>& ret,
   const std::wstring& stringToExplode, 
   wchar_t strDelimit,
-  unsigned int nCount /*=MYODD_MAX_INT32*/,
+  int maxnumberOfElements /*=MYODD_MAX_INT32*/,
   bool bAddEmpty /*= true*/
 )
 {
   //  reset all
   ret.clear();
 
-  // return if we have no work to do.
-  // If the limit parameter is zero, then this is treated as 1.
-  if( 1 == nCount || 0 == nCount )
+  // if we have zero or 1 element then there is nothing to explode
+  // we just put the one string in the vector and return that.
+  if( 1 == maxnumberOfElements || 0 == maxnumberOfElements)
   {
     ret.push_back(stringToExplode);
     return 1;
   }
   
   // reserve space.
-  if( nCount > 1 && nCount != MYODD_MAX_INT32 )
+  if(maxnumberOfElements > 1 && maxnumberOfElements != MYODD_MAX_INT32 )
   {
-    ret.reserve( nCount );
+    ret.reserve(maxnumberOfElements);
   }
 
   // get the given vector length 
@@ -209,7 +211,7 @@ unsigned int Explode
       if( bAddEmpty || (pos-iLast) > 0 )
       {
         ++retSize;
-        if (nCount > 1 && retSize >= nCount)
+        if (maxnumberOfElements > 1 && retSize >= maxnumberOfElements)
         {
           // we have collected more items than we want.
           // so we can just stop here and add everything else to our container.
@@ -227,10 +229,10 @@ unsigned int Explode
     }
   }
 
-  // If count is negative, we only return retSize - count items.
-  if( nCount < 0 )
+  // If count is negative, we only return retSize - maxnumberOfElements items.
+  if(maxnumberOfElements < 0 )
   {
-    const auto positiveCount = static_cast<const unsigned int>(nCount * -1);
+    const auto positiveCount = static_cast<const unsigned int>(maxnumberOfElements * -1);
     if(positiveCount >= retSize )
     {
       // we want less items that are actually available
@@ -240,8 +242,8 @@ unsigned int Explode
     }
     else
     {
-      retSize += nCount;  // nCount is negative so we want all the items
-                          // in the vector minus the last '-ve count' ones
+      retSize += maxnumberOfElements;  // nCount is negative so we want all the items
+                                       // in the vector minus the last '-ve count' ones
       ret.erase( ret.begin()+retSize, ret.end());
     }
   }

--- a/myodd/string/string.h
+++ b/myodd/string/string.h
@@ -46,22 +46,38 @@ namespace myodd{ namespace strings{
 
   int32_t Compare( const std::wstring& lhs, const std::wstring& rhs, bool caseSensitive = true);
 
-  // explode with a '\0' char
-  size_t explode_by_null_char
+  /**
+   * \brief Explode a string that is separated with '\0' chars.
+   *        This is used with items like GetPrivateProfileString( ... ) when we want to list all the keys.
+   * \param ret the return container.
+   * \param s_keys the string with null chars '\0' finished by '\0\0'
+   * \param nLen the length of the string.
+   * \return int the number of items we exploded the string to.
+   */
+  unsigned int explode_by_null_char
     (
-    std::vector<std::wstring>& ret,
-    const wchar_t* s_keys,
-    size_t nLen
+      std::vector<std::wstring>& ret,
+      const wchar_t* s_keys,
+      unsigned int nLen
     );
 
-  // explode a string with a set of delimiter characters
-  size_t Explode
+  /**
+   * \brief Explode a given string given a delimiter string
+   * \param ret the return container.
+   * \param stringToExplode the string we want to explode
+   * \param strDelimit Set of delimiter characters.
+   * \param nCount the max number of items we want to return.
+   *               If the limit parameter is zero, then this is treated as 1.
+   * \param bAddEmpty if we want to add empty params or not.
+   * \return the number of item that we found.
+   */
+  unsigned int Explode
     (
-    std::vector<std::wstring>& ret,
-    const std::wstring& s, 
-    wchar_t strDelimit,
-    int nCount = MYODD_MAX_INT32,
-    bool bAddEmpty = true
+      std::vector<std::wstring>& ret,
+      const std::wstring& stringToExplode,
+      wchar_t strDelimit,
+      unsigned int nCount =MYODD_MAX_INT32,
+      bool bAddEmpty = true
     );
 
   // implode a string

--- a/myodd/string/string.h
+++ b/myodd/string/string.h
@@ -66,8 +66,10 @@ namespace myodd{ namespace strings{
    * \param ret the return container.
    * \param stringToExplode the string we want to explode
    * \param strDelimit Set of delimiter characters.
-   * \param nCount the max number of items we want to return.
-   *               If the limit parameter is zero, then this is treated as 1.
+   * \param maxnumberOfElements the max number of items we want to return.
+   *               If the limit parameter is zero, then this is treated as 1, (and only return one element).
+   *               If the value is negative, we return the (total - n) number of elements, (from 0 to total - count)
+   *                  If the negative number is greater than the total number of elements, we return nothing.
    * \param bAddEmpty if we want to add empty params or not.
    * \return the number of item that we found.
    */
@@ -76,7 +78,7 @@ namespace myodd{ namespace strings{
       std::vector<std::wstring>& ret,
       const std::wstring& stringToExplode,
       wchar_t strDelimit,
-      unsigned int nCount =MYODD_MAX_INT32,
+      int maxnumberOfElements =MYODD_MAX_INT32,
       bool bAddEmpty = true
     );
 

--- a/myoddtest/dynamic/testany_char.cpp
+++ b/myoddtest/dynamic/testany_char.cpp
@@ -490,7 +490,7 @@ TEST_MEM(AnyTestCharacter, StdStringPointerConstructor)
 
 TEST_MEM_LOOP(AnyTestCharacter, GetUnsignedCharPtrWithNoNullTerminatorInsideString, NUMBER_OF_TESTS)
 {
-  const size_t len = (size_t)CharRandom<unsigned char>() + 1; // make sure we never have zero
+  const auto len = CharRandom<unsigned char>() + 1; // make sure we never have zero
   unsigned char* c = new unsigned char[len];
   memset(c, 0, len);
   for (auto i = 0; i < len-1; ++i)
@@ -518,7 +518,7 @@ TEST_MEM_LOOP(AnyTestCharacter, GetUnsignedCharPtrWithNoNullTerminatorInsideStri
 
 TEST_MEM_LOOP(AnyTestCharacter, GetSignedCharPtrWithNoNullTerminatorInsideString, NUMBER_OF_TESTS)
 {
-  const size_t len = (size_t)CharRandom<unsigned char>() + 1; // make sure we never have zero
+  const auto len = CharRandom<unsigned char>() + 1; // make sure we never have zero
   signed char* c = new signed char[len];
   memset(c, 0, len);
   for (auto i = 0; i < len; ++i)
@@ -546,7 +546,7 @@ TEST_MEM_LOOP(AnyTestCharacter, GetSignedCharPtrWithNoNullTerminatorInsideString
 
 TEST_MEM_LOOP(AnyTestCharacter, GetCharPtrWithNoNullTerminatorInsideString, NUMBER_OF_TESTS)
 {
-  const size_t len = (size_t)CharRandom<unsigned char>() + 1; // make sure we never have zero
+  const auto len = CharRandom<unsigned char>() + 1; // make sure we never have zero
   char* c = new char[len];
   memset(c, 0, len);
   for (auto i = 0; i < len-1; ++i)
@@ -574,7 +574,7 @@ TEST_MEM_LOOP(AnyTestCharacter, GetCharPtrWithNoNullTerminatorInsideString, NUMB
 
 TEST_MEM_LOOP(AnyTestCharacter, GetWideCharPtrWithNoNullTerminatorInsideString, NUMBER_OF_TESTS)
 {
-  const size_t len = (size_t)CharRandom<unsigned char>() +1; // make sure we never have zero
+  const auto len = CharRandom<unsigned char>() +1; // make sure we never have zero
   wchar_t* c = new wchar_t[len];
   memset(c, 0, len);
   for (auto i = 0; i < len - 1; ++i)
@@ -602,7 +602,7 @@ TEST_MEM_LOOP(AnyTestCharacter, GetWideCharPtrWithNoNullTerminatorInsideString, 
 
 TEST_MEM_LOOP(AnyTestCharacter, GetWideCharPtrWithLength, NUMBER_OF_TESTS)
 {
-  const size_t len = (size_t)CharRandom<unsigned char>() + 1; // make sure we never have zero
+  const auto len = CharRandom<unsigned char>() + 1; // make sure we never have zero
   wchar_t* c = new wchar_t[len];
   memset(c, 0, len);
   for (auto i = 0; i < len; ++i)
@@ -624,7 +624,7 @@ TEST_MEM_LOOP(AnyTestCharacter, GetWideCharPtrWithLength, NUMBER_OF_TESTS)
 
 TEST_MEM_LOOP(AnyTestCharacter, GetCharPtrWithLength, NUMBER_OF_TESTS)
 {
-  const size_t len = (size_t)CharRandom<unsigned char>() + 1; // make sure we never have zero
+  const auto len = CharRandom<unsigned char>() + 1; // make sure we never have zero
   char* c = new char[len];
   memset(c, 0, len);
   for (auto i = 0; i < len; ++i)

--- a/myoddtest/dynamic/testany_trivialcopy.cpp
+++ b/myoddtest/dynamic/testany_trivialcopy.cpp
@@ -284,14 +284,14 @@ TEST_MEM(AnyTestTrivialCopy, CannotCastTrivialToString)
 {
   TrivialStruct ts = { IntRandomNumber<int>(false), IntRandomNumber<int>(false) };
   ::myodd::dynamic::Any any(ts);
-  EXPECT_THROW(std::string( (const char*)any) != std::string((const char*)any), std::bad_cast);
+  EXPECT_THROW((void)(std::string( (const char*)any) != std::string((const char*)any)), std::bad_cast);
 }
 
 TEST_MEM(AnyTestTrivialCopy, CannotCastTrivialToWideString)
 {
   TrivialStruct ts = { IntRandomNumber<int>(false), IntRandomNumber<int>(false) };
   ::myodd::dynamic::Any any(ts);
-  EXPECT_THROW(std::wstring((const wchar_t*)any) != std::wstring((const wchar_t*)any), std::bad_cast);
+  EXPECT_THROW((void)(std::wstring((const wchar_t*)any) != std::wstring((const wchar_t*)any)), std::bad_cast);
 }
 
 TEST_MEM(AnyTestTrivialCopy, CannotCastTrivialToBoolean)

--- a/myoddtest/os/testipcdata.cpp
+++ b/myoddtest/os/testipcdata.cpp
@@ -297,7 +297,7 @@ TEST_MEM(MyoddOsTest, CompareJustAWideString)
   ASSERT_EQ(ipc, ipc2);
 }
 
-void CreateRandomIpcData( const size_t size, myodd::os::IpcData& parent)
+void CreateRandomIpcData( const int size, myodd::os::IpcData& parent)
 {
   for (auto i = 0; i < size; ++i)
   {
@@ -332,12 +332,12 @@ TEST_MEM(MyoddOsTest, AssignValueToAnItemThatAlreadyHasValues)
   // create 2 ipc
   auto uuid1 = Uuid();
   auto ipc1 = myodd::os::IpcData(uuid1);
-  auto size1 = IntRandomNumber<size_t>(20, 50);
+  auto size1 = IntRandomNumber<int>(20, 50);
   CreateRandomIpcData(size1, ipc1);
 
   auto uuid2 = Uuid();
   auto ipc2 = myodd::os::IpcData(uuid2);
-  auto size2 = IntRandomNumber<size_t>(20, 50);
+  auto size2 = IntRandomNumber<int>(20, 50);
   CreateRandomIpcData(size2, ipc2);
 
   // now assign 1 to 2
@@ -352,7 +352,7 @@ TEST_MEM_LOOP(MyoddOsTest, CompareVariousTypeSizes, NUMBER_OF_TESTS)
   // create the ipc
   auto uuid = Uuid();
   auto ipc = myodd::os::IpcData(uuid);
-  auto size = IntRandomNumber<size_t>(20, 50);
+  auto size = IntRandomNumber<int>(20, 50);
   CreateRandomIpcData(size, ipc);
 
   // copy it
@@ -367,7 +367,7 @@ TEST_MEM_LOOP(MyoddOsTest, CompareVariousTypeSizesButNotQuiteSame, NUMBER_OF_TES
   // create the ipc
   auto uuid = Uuid();
   auto ipc = myodd::os::IpcData(uuid);
-  auto size = IntRandomNumber<size_t>(20, 50);
+  auto size = IntRandomNumber<int>(20, 50);
   CreateRandomIpcData(size, ipc);
 
   // copy it

--- a/myoddtest/string/teststring_explode.cpp
+++ b/myoddtest/string/teststring_explode.cpp
@@ -140,3 +140,47 @@ INSTANTIATE_TEST_SUITE_P(VariousCountSizeWithAddEmptyFlag, MyOddStringExplodeWit
     test_explode{ L",, ,,", L',',{ L" " }, 1, MYODD_MAX_INT32, false },  //  a space is not empty
     test_explode{ L"", L',',{}, 0, MYODD_MAX_INT32, false }
 ));
+
+TEST(ExplodeString, NegativeCountWillReturnTheTotalNumberLessTheCount)
+{
+  std::vector<std::wstring> s;
+  const auto l = myodd::strings::Explode(
+    s,
+    L"1,2,3,4,5", L',', -2);
+
+  // we have 5 items in the array, we want -2 numbers
+  // in other words, we want 5 - 2 = 3
+  std::vector<std::wstring> expected = { L"1",L"2",L"3" };
+
+  ASSERT_EQ(3, l);
+  ASSERT_EQ(expected, s);
+};
+
+TEST(ExplodeString, NegativeCountBiggerThanTheToalWillReturnNothing)
+{
+  std::vector<std::wstring> s;
+  const auto l = myodd::strings::Explode(
+    s,
+    L"1,2,3,4,5", L',', -10);
+
+  // we have 5 items in the array, we want -10 numbers
+  // in other words, we want 5 - 10 = -5
+  // we can't do that, so we will return noting
+  std::vector<std::wstring> expected = {};
+
+  ASSERT_EQ(0, l);
+  ASSERT_EQ(expected, s);
+};
+
+TEST(ExplodeString, ZeroCountWillReturnSingleString)
+{
+  std::vector<std::wstring> s;
+  const auto l = myodd::strings::Explode(
+    s,
+    L"1,2,3,4,5", L',', 0);
+
+  std::vector<std::wstring> expected = { L"1,2,3,4,5" };
+
+  ASSERT_EQ(1, l);
+  ASSERT_EQ(expected, s);
+};


### PR DESCRIPTION
Fixd an issue in `memcpy_s` where we were passing the wrong max size, this was causing a warning of potential overrun.
Fixes issue #83